### PR TITLE
Improve .NET Core project.json

### DIFF
--- a/Cottle.Test/project.json
+++ b/Cottle.Test/project.json
@@ -1,28 +1,39 @@
 ﻿{
-	"version" : "1.1.5-*",
-	"runtimes" : {
-		"win7-x64" : {},
-		"ubuntu.14.04-x64" : {}
-	},
-	"dependencies" : {
-		"Cottle" : {
-			"target" : "project"
-		},
-		"NUnit" : "3.4.0",
-		"dotnet-test-nunit" : "3.4.0-beta-2"
-	},
-	"testRunner" : "nunit",
-	"frameworks" : {
-		"netcoreapp1.0" : {
-			"imports" : [
-				"portable-net45+win8"
-			],
-			"dependencies" : {
-				"NETStandard.Library" : "1.6.0"
-			},
-			"buildOptions" : {
-				"define" : ["CORECLR"]
-			}
-		}
-	}
+  "dependencies": {
+    "Cottle": {
+      "target": "project"
+    },
+    "NUnit": "3.4.0",
+    "dotnet-test-nunit": "3.4.0-beta-2"
+  },
+  "configurations": {
+    "Debug": {
+      "buildOptions": {
+        "define": [ "DEBUG" ]
+      }
+    },
+    "Release": {
+      "buildOptions": {
+        "define": [ "RELEASE" ],
+        "optimize": true
+      }
+    }
+  },
+  "testRunner": "nunit",
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "portable-net45+win8"
+      ],
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0",
+          "type": "platform"
+        }
+      },
+      "buildOptions": {
+        "define": [ "CORECLR" ]
+      }
+    }
+  }
 }

--- a/Cottle/project.json
+++ b/Cottle/project.json
@@ -1,30 +1,52 @@
 ﻿{
-	"version" : "1.1.5-*",
-	"title" : "Cottle: Compact Object to Text Transform Language",
-	"description" : "Lightweight & extensible template library for .NET 3.5 and above.",
-	"authors" : ["Remi Caput"],
-	"packOptions" : {
-		"projectUrl" : "http://r3c.github.io/cottle/",
-		"tags" : ["Template Templating Engine HTML JavaScript Email"],
-		"licenseUrl" : "https://raw.github.com/r3c/cottle/master/LICENSE.md",
-		"iconUrl" : "https://raw.github.com/r3c/cottle/master/icon.png",
-		"repository" : {
-			"type" : "git",
-			"url" : "git://github.com/r3c/cottle"
-		}
-	},
-	"frameworks" : {
-		"net35" : {},
-		"netstandard1.5" : {
-			"dependencies" : {
-				"NETStandard.Library" : "1.6.0",
-				"System.Reflection.Emit" : "4.0.1",
-				"System.Reflection.TypeExtensions" : "4.1.0",
-				"System.Reflection.Emit.Lightweight" : "4.0.1"
-			},
-			"buildOptions" : {
-				"define" : ["CORECLR"]
-			}
-		}
-	}
+  "version": "1.1.5-*",
+  "title": "Cottle: Compact Object to Text Transform Language",
+  "description": "Lightweight & extensible template library for .NET 3.5 and above.",
+  "authors": [ "Remi Caput" ],
+  "packOptions": {
+    "projectUrl": "http://r3c.github.io/cottle/",
+    "tags": [ "Template Templating Engine HTML JavaScript Email" ],
+    "licenseUrl": "https://raw.github.com/r3c/cottle/master/LICENSE.md",
+    "iconUrl": "https://raw.github.com/r3c/cottle/master/icon.png",
+    "repository": {
+      "type": "git",
+      "url": "git://github.com/r3c/cottle"
+    }
+  },
+  "configurations": {
+    "Debug": {
+      "buildOptions": {
+        "define": [ "DEBUG" ]
+      }
+    },
+    "Release": {
+      "buildOptions": {
+        "define": [ "RELEASE" ],
+        "optimize": true
+      }
+    }
+  },
+  "frameworks": {
+    "net35": {},
+    "netstandard1.5": {
+      "dependencies": {
+        "System.Globalization": "4.0.11",
+        "System.Linq": "4.1.0",
+        "System.Linq.Expressions": "4.1.0",
+        "System.Reflection": "4.1.0",
+        "System.Reflection.Extensions": "4.0.1",
+        "System.Reflection.Emit": "4.0.1",
+        "System.Reflection.TypeExtensions": "4.1.0",
+        "System.Reflection.Emit.Lightweight": "4.0.1",
+        "System.Runtime": "4.1.0",
+        "System.Runtime.Extensions": "4.1.0",
+        "System.Runtime.InteropServices": "4.1.0",
+        "System.Text.RegularExpressions": "4.1.0",
+        "System.Threading": "4.0.11"
+      },
+      "buildOptions": {
+        "define": [ "CORECLR" ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Specify the exact dependencies instead of relying on NETStandard meta package
- Add Debug and Release configurations
- UTests: use "platform" type to avoid specifying the runtimes
- UTests: remove useless version field