### PR TITLE
Remove unnecessary conditional compilation directives for .NET Core

### DIFF
--- a/Cottle/src/Builtins/BuiltinFunctions.cs
+++ b/Cottle/src/Builtins/BuiltinFunctions.cs
@@ -229,11 +229,7 @@ namespace Cottle.Builtins
 				return -1;
 			}
 			else
-#if CORECLR
-				return source.AsString.IndexOf (search.AsString, offset);
-#else
-				return source.AsString.IndexOf (search.AsString, offset, StringComparison.InvariantCulture);
-#endif
+				return source.AsString.IndexOf (search.AsString, offset, StringComparison.Ordinal);
 		}, 2, 3);
 
 		private static readonly IFunction	functionFlip = new NativeFunction ((values) =>
@@ -588,11 +584,8 @@ namespace Cottle.Builtins
 			search = values[1].AsString;
 			source = values[0].AsString;
 			start = 0;
-#if CORECLR
-			stop = source.IndexOf (search);
-#else
-			stop = source.IndexOf (search, StringComparison.InvariantCulture);
-#endif
+
+			stop = source.IndexOf (search, StringComparison.Ordinal);
 
 			for (int i = Math.Max ((int)values[2].AsNumber, 0); i > 0; --i)
 			{
@@ -604,11 +597,7 @@ namespace Cottle.Builtins
 				}
 
 				start = stop + search.Length;
-#if CORECLR
-				stop = source.IndexOf (search, start);
-#else
-				stop = source.IndexOf (search, start, StringComparison.InvariantCulture);
-#endif
+				stop = source.IndexOf (search, start, StringComparison.Ordinal);
 			}
 
 			if (values.Count < 4)

--- a/Cottle/src/Documents/Simple/Nodes/EchoNode.cs
+++ b/Cottle/src/Documents/Simple/Nodes/EchoNode.cs
@@ -40,11 +40,7 @@ namespace Cottle.Documents.Simple.Nodes
 
 			output.Write (setting.BlockBegin);
 
-#if CORECLR
-			if (source.StartsWith ("echo"))
-#else
-			if (source.StartsWith ("echo", StringComparison.InvariantCulture))
-#endif
+			if (source.StartsWith ("echo", StringComparison.Ordinal))
 				output.Write ("echo ");
 
 			output.Write (source);

--- a/Cottle/src/Parsers/Default/Lexer.cs
+++ b/Cottle/src/Parsers/Default/Lexer.cs
@@ -157,11 +157,8 @@ namespace Cottle.Parsers.Default
 
 						this.pending.Enqueue (this.last);
 						this.last = '&';
-#if CORECLR
+
 						return new Lexem (LexemType.None, this.last.ToString ());
-#else
-						return new Lexem (LexemType.None, this.last.ToString (CultureInfo.InvariantCulture));
-#endif
 
 					case '(':
 						return this.NextChar (LexemType.ParenthesisBegin);
@@ -301,11 +298,8 @@ namespace Cottle.Parsers.Default
 
 						this.pending.Enqueue (this.last);
 						this.last = '|';
-#if CORECLR
+
 						return new Lexem (LexemType.None, this.last.ToString ());
-#else
-						return new Lexem (LexemType.None, this.last.ToString (CultureInfo.InvariantCulture));
-#endif
 
 					case '[':
 						return this.NextChar (LexemType.BracketBegin);
@@ -332,11 +326,8 @@ namespace Cottle.Parsers.Default
 						return new Lexem (LexemType.String, buffer.ToString ());
 
 					default:
-#if CORECLR
 						return new Lexem (LexemType.None, this.last.ToString ());
-#else
-						return new Lexem (LexemType.None, this.last.ToString (CultureInfo.InvariantCulture));
-#endif
+
 				}
 			}
 		}
@@ -344,11 +335,8 @@ namespace Cottle.Parsers.Default
 		private Lexem NextChar (LexemType type)
 		{
 			Lexem	lexem;
-#if CORECLR
+
 			lexem = new Lexem (type, this.last.ToString ());
-#else
-			lexem = new Lexem (type, this.last.ToString (CultureInfo.InvariantCulture));
-#endif
 
 			this.Read ();
 


### PR DESCRIPTION
- Ordinal string comparison seems more appropriate
than CultureInvariant for "find" and "token".

- Specifying the culture to convert char to string is unnecessary:
https://msdn.microsoft.com/en-us/library/yta41sb3(v=vs.110).aspx
"The provider parameter is ignored; it does not participate in this operation"