### PR TITLE
Add NetStandard 2.0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      dotnet: 1.0.4
+      dotnet: 2.0.0
       mono: latest
 
 install:
@@ -19,6 +19,7 @@ script:
   - rm -fr ./artifacts
   - dotnet restore Cottle.dotnetcore.sln
   - dotnet build ./Cottle/Cottle.dotnetcore.csproj -c Release -f netstandard1.5
-  - dotnet build ./Cottle.Test/Cottle.Test.dotnetcore.csproj -c Release -f netcoreapp1.1
-  - dotnet test ./Cottle.Test/Cottle.Test.dotnetcore.csproj -c Release -f netcoreapp1.1
+  - dotnet build ./Cottle/Cottle.dotnetcore.csproj -c Release -f netstandard2.0
+  - dotnet build ./Cottle.Test/Cottle.Test.dotnetcore.csproj -c Release -f netcoreapp2.0
+  - dotnet test ./Cottle.Test/Cottle.Test.dotnetcore.csproj -c Release -f netcoreapp2.0
 #  - dotnet pack ./Cottle/Cottle.dotnetcore.csproj -c Release -o ./artifacts

--- a/Cottle.Test/Cottle.Test.dotnetcore.csproj
+++ b/Cottle.Test/Cottle.Test.dotnetcore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyName>Cottle.Test</AssemblyName>
     <PackageId>Cottle.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
@@ -14,15 +14,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="NUnit" Version="3.8.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/Cottle/Cottle.dotnetcore.csproj
+++ b/Cottle/Cottle.dotnetcore.csproj
@@ -5,7 +5,7 @@
     <AssemblyTitle>Cottle: Compact Object to Text Transform Language</AssemblyTitle>
     <Version>1.4.0.3</Version>
     <Authors>Remi Caput</Authors>
-    <TargetFrameworks>netstandard1.5;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net40</TargetFrameworks>
     <AssemblyName>Cottle</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>Cottle</PackageId>


### PR DESCRIPTION
System.Converter delegate wasn't available in NetStandard <= 1.6 and was copied into the project.
It is now available in 2.0, thus the file was dropped from the assembly for this target.

We could also drop NetStandard 1.5 build. Maybe in a few months when 2.0 will be more spread?