### PR TITLE
Remove NetStandard1.5 build and bump to 1.4.0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ script:
 # - nuget pack -Prop Configuration=Release -Prop Platform=AnyCPU ./Cottle/Cottle.csproj
   - rm -fr ./artifacts
   - dotnet restore Cottle.dotnetcore.sln
-  - dotnet build ./Cottle/Cottle.dotnetcore.csproj -c Release -f netstandard1.5
   - dotnet build ./Cottle/Cottle.dotnetcore.csproj -c Release -f netstandard2.0
   - dotnet build ./Cottle.Test/Cottle.Test.dotnetcore.csproj -c Release -f netcoreapp2.0
   - dotnet test ./Cottle.Test/Cottle.Test.dotnetcore.csproj -c Release -f netcoreapp2.0

--- a/Cottle/Cottle.csproj
+++ b/Cottle/Cottle.csproj
@@ -132,7 +132,6 @@
     <Compile Include="src\Value.cs" />
     <Compile Include="src\ValueContent.cs" />
     <Compile Include="src\Values\BooleanValue.cs" />
-    <Compile Include="src\Values\Converter.cs" />
     <Compile Include="src\Values\LazyValue.cs" />
     <Compile Include="src\Values\MapValue.cs" />
     <Compile Include="src\Values\ReflectionValue.cs" />

--- a/Cottle/Cottle.dotnetcore.csproj
+++ b/Cottle/Cottle.dotnetcore.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <Description>Lightweight &amp; extensible template library for .NET 4.0 and above.</Description>
     <AssemblyTitle>Cottle: Compact Object to Text Transform Language</AssemblyTitle>
-    <Version>1.4.0.3</Version>
+    <Version>1.4.0.4</Version>
     <Authors>Remi Caput</Authors>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <AssemblyName>Cottle</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>Cottle</PackageId>
@@ -17,14 +17,11 @@
     <RepositoryUrl>git://github.com/r3c/cottle</RepositoryUrl>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' OR '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/Cottle/src/Builtins/BuiltinFunctions.cs
+++ b/Cottle/src/Builtins/BuiltinFunctions.cs
@@ -255,11 +255,7 @@ namespace Cottle.Builtins
 			int index;
 			object target;
 
-#if NETSTANDARD1_5
-			culture = values.Count > 2 ? new CultureInfo (values[2].AsString) : CultureInfo.CurrentCulture;
-#else
 			culture = values.Count > 2 ? CultureInfo.GetCultureInfo (values[2].AsString) : CultureInfo.CurrentCulture;
-#endif
 			format = values[1].AsString;
 			index = format.IndexOf (':');
 

--- a/Cottle/src/Documents/Dynamic/Function.cs
+++ b/Cottle/src/Documents/Dynamic/Function.cs
@@ -79,7 +79,7 @@ namespace Cottle.Documents.Dynamic
 			ModuleBuilder module;
 			TypeBuilder program;
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD2_0
 			assembly = AssemblyBuilder.DefineDynamicAssembly (new AssemblyName (assemblyName), AssemblyBuilderAccess.Run);
 			module = assembly.DefineDynamicModule (fileName);
 #else
@@ -93,7 +93,7 @@ namespace Cottle.Documents.Dynamic
 			compiler = new Compiler (method.GetILGenerator (), trimmer);
 			compiler.Compile (Enumerable.Empty<string> (), command);
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD2_0
 			program.CreateTypeInfo ();
 #else
 			program.CreateType ();

--- a/Cottle/src/Values/Converter.cs
+++ b/Cottle/src/Values/Converter.cs
@@ -1,6 +1,0 @@
-﻿#if NETSTANDARD1_5
-namespace System
-{
-  public delegate TOutput Converter<TInput, TOutput> (TInput input);
-}
-#endif

--- a/Cottle/src/Values/ReflectionValue.cs
+++ b/Cottle/src/Values/ReflectionValue.cs
@@ -74,11 +74,7 @@ namespace Cottle.Values
 				return converter (this.source);
 
 			// Return undefined value for other primitive types
-#if NETSTANDARD1_5
-			if (type.GetTypeInfo ().IsPrimitive)
-#else
 			if (type.IsPrimitive)
-#endif
 				return VoidValue.Instance;
 
 			// Convert elements to array if source object is enumerable


### PR DESCRIPTION
Removing 1.5 allows us to remove Converter.cs.
Moreover 1.5 and 2.0 are both usable from net461.