### PR TITLE
Move store mode out of `Symbol` type.

### DIFF
--- a/src/Cottle/Documents/Compiled/Scope.cs
+++ b/src/Cottle/Documents/Compiled/Scope.cs
@@ -36,12 +36,10 @@ namespace Cottle.Documents.Compiled
             return new Scope(_globals);
         }
 
-        public Symbol GetOrDeclareClosest(string name, StoreMode mode)
+        public (Symbol, StoreMode) GetOrDeclareClosest(string name, StoreMode mode)
         {
-            if (TryGetLocal(name, out var local))
-                return new Symbol(local, StoreMode.Local);
-
-            int index;
+            if (TryGetLocal(name, out var index))
+                return (new Symbol(index), StoreMode.Local);
 
             if (mode == StoreMode.Local)
             {
@@ -56,19 +54,19 @@ namespace Cottle.Documents.Compiled
                 _globals[name] = index;
             }
 
-            return new Symbol(index, mode);
+            return (new Symbol(index), mode);
         }
 
         public Symbol GetOrDeclareLocal(string name)
         {
             if (TryGetLocal(name, out var local))
-                return new Symbol(local, StoreMode.Local);
+                return new Symbol(local);
 
             var index = _unique++;
 
             SetLocal(name, index);
 
-            return new Symbol(index, StoreMode.Local);
+            return new Symbol(index);
         }
 
         public void Enter()

--- a/src/Cottle/Documents/Compiled/Symbol.cs
+++ b/src/Cottle/Documents/Compiled/Symbol.cs
@@ -1,14 +1,12 @@
-namespace Cottle.Documents.Compiled
+﻿namespace Cottle.Documents.Compiled
 {
-    public readonly struct Symbol
+    internal readonly struct Symbol
     {
         public readonly int Index;
-        public readonly StoreMode Mode;
 
-        public Symbol(int index, StoreMode mode)
+        public Symbol(int index)
         {
             Index = index;
-            Mode = mode;
         }
     }
 }

--- a/src/Cottle/Documents/Emitted/Assembler.cs
+++ b/src/Cottle/Documents/Emitted/Assembler.cs
@@ -31,9 +31,9 @@ namespace Cottle.Documents.Emitted
             return new MapExpressionGenerator(elements);
         }
 
-        protected override IExpressionGenerator CreateExpressionSymbol(Symbol symbol)
+        protected override IExpressionGenerator CreateExpressionSymbol(Symbol symbol, StoreMode mode)
         {
-            return new SymbolExpressionGenerator(symbol);
+            return new SymbolExpressionGenerator(symbol, mode);
         }
 
         protected override IExpressionGenerator CreateExpressionVoid()
@@ -41,21 +41,20 @@ namespace Cottle.Documents.Emitted
             return new ConstantExpressionGenerator(Value.Undefined);
         }
 
-        protected override IStatementGenerator CreateStatementAssignFunction(Symbol symbol, int localCount,
+        protected override IStatementGenerator CreateStatementAssignFunction(Symbol symbol, StoreMode mode, int localCount,
             IReadOnlyList<Symbol> arguments, IStatementGenerator body)
         {
-            return new AssignFunctionStatementGenerator(symbol, arguments, body);
+            return new AssignFunctionStatementGenerator(symbol, mode, arguments, body);
         }
 
-        protected override IStatementGenerator CreateStatementAssignRender(Symbol symbol, IStatementGenerator body)
+        protected override IStatementGenerator CreateStatementAssignRender(Symbol symbol, StoreMode mode, IStatementGenerator body)
         {
-            return new AssignRenderStatementGenerator(symbol, body);
+            return new AssignRenderStatementGenerator(symbol, mode, body);
         }
 
-        protected override IStatementGenerator CreateStatementAssignValue(Symbol symbol,
-            IExpressionGenerator expression)
+        protected override IStatementGenerator CreateStatementAssignValue(Symbol symbol, StoreMode mode, IExpressionGenerator expression)
         {
-            return new AssignValueStatementGenerator(symbol, expression);
+            return new AssignValueStatementGenerator(symbol, mode, expression);
         }
 
         protected override IStatementGenerator CreateStatementComposite(IReadOnlyList<IStatementGenerator> statements)

--- a/src/Cottle/Documents/Emitted/Execute.cs
+++ b/src/Cottle/Documents/Emitted/Execute.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using Cottle.Documents.Compiled;
-using Cottle.Documents.Evaluated;
 
 namespace Cottle.Documents.Emitted
 {

--- a/src/Cottle/Documents/Emitted/ExpressionGenerators/SymbolExpressionGenerator.cs
+++ b/src/Cottle/Documents/Emitted/ExpressionGenerators/SymbolExpressionGenerator.cs
@@ -5,16 +5,18 @@ namespace Cottle.Documents.Emitted.ExpressionGenerators
 {
     internal class SymbolExpressionGenerator : IExpressionGenerator
     {
+        private readonly StoreMode _mode;
         private readonly Symbol _symbol;
 
-        public SymbolExpressionGenerator(Symbol symbol)
+        public SymbolExpressionGenerator(Symbol symbol, StoreMode mode)
         {
+            _mode = mode;
             _symbol = symbol;
         }
 
         public void Generate(Emitter emitter)
         {
-            switch (_symbol.Mode)
+            switch (_mode)
             {
                 case StoreMode.Global:
                     emitter.EmitLoadFrameGlobal();
@@ -24,7 +26,7 @@ namespace Cottle.Documents.Emitted.ExpressionGenerators
                     break;
 
                 case StoreMode.Local:
-                    emitter.EmitLoadLocalValue(emitter.GetOrDeclareSymbol(_symbol.Index));
+                    emitter.EmitLoadLocalValue(emitter.GetOrDeclareLocal(_symbol));
 
                     break;
 

--- a/src/Cottle/Documents/Emitted/Program.cs
+++ b/src/Cottle/Documents/Emitted/Program.cs
@@ -50,7 +50,7 @@ namespace Cottle.Documents.Emitted
                 emitter.EmitLoadFrameArgumentLength();
                 emitter.EmitBranchWhenGreaterOrEqual(body);
                 emitter.EmitLoadFrameArgument(i);
-                emitter.EmitStoreLocal(emitter.GetOrDeclareSymbol(arguments[i].Index));
+                emitter.EmitStoreLocal(emitter.GetOrDeclareLocal(arguments[i]));
             }
 
             // Execute function body and return

--- a/src/Cottle/Documents/Emitted/StatementGenerators/AssignRenderStatementGenerator.cs
+++ b/src/Cottle/Documents/Emitted/StatementGenerators/AssignRenderStatementGenerator.cs
@@ -7,11 +7,13 @@ namespace Cottle.Documents.Emitted.StatementGenerators
     internal class AssignRenderStatementGenerator : IStatementGenerator
     {
         private readonly IStatementGenerator _body;
+        private readonly StoreMode _mode;
         private readonly Symbol _symbol;
 
-        public AssignRenderStatementGenerator(Symbol symbol, IStatementGenerator body)
+        public AssignRenderStatementGenerator(Symbol symbol, StoreMode mode, IStatementGenerator body)
         {
             _body = body;
+            _mode = mode;
             _symbol = symbol;
         }
 
@@ -38,7 +40,7 @@ namespace Cottle.Documents.Emitted.StatementGenerators
             var result = emitter.EmitDeclareLocalAndStore<Value>();
 
             // Render output buffer and store as local
-            switch (_symbol.Mode)
+            switch (_mode)
             {
                 case StoreMode.Global:
                     emitter.EmitLoadFrameGlobal();
@@ -50,7 +52,7 @@ namespace Cottle.Documents.Emitted.StatementGenerators
 
                 case StoreMode.Local:
                     emitter.EmitLoadLocalValueAndRelease(result);
-                    emitter.EmitStoreLocal(emitter.GetOrDeclareSymbol(_symbol.Index));
+                    emitter.EmitStoreLocal(emitter.GetOrDeclareLocal(_symbol));
 
                     break;
 

--- a/src/Cottle/Documents/Emitted/StatementGenerators/AssignValueStatementGenerator.cs
+++ b/src/Cottle/Documents/Emitted/StatementGenerators/AssignValueStatementGenerator.cs
@@ -6,11 +6,13 @@ namespace Cottle.Documents.Emitted.StatementGenerators
     internal class AssignValueStatementGenerator : IStatementGenerator
     {
         private readonly IExpressionGenerator _expression;
+        private readonly StoreMode _mode;
         private readonly Symbol _symbol;
 
-        public AssignValueStatementGenerator(Symbol symbol, IExpressionGenerator expression)
+        public AssignValueStatementGenerator(Symbol symbol, StoreMode mode, IExpressionGenerator expression)
         {
             _expression = expression;
+            _mode = mode;
             _symbol = symbol;
         }
 
@@ -20,7 +22,7 @@ namespace Cottle.Documents.Emitted.StatementGenerators
 
             var result = emitter.EmitDeclareLocalAndStore<Value>();
 
-            switch (_symbol.Mode)
+            switch (_mode)
             {
                 case StoreMode.Global:
                     emitter.EmitLoadFrameGlobal();
@@ -32,7 +34,7 @@ namespace Cottle.Documents.Emitted.StatementGenerators
 
                 case StoreMode.Local:
                     emitter.EmitLoadLocalValueAndRelease(result);
-                    emitter.EmitStoreLocal(emitter.GetOrDeclareSymbol(_symbol.Index));
+                    emitter.EmitStoreLocal(emitter.GetOrDeclareLocal(_symbol));
 
                     break;
 

--- a/src/Cottle/Documents/Emitted/StatementGenerators/ForStatementGenerator.cs
+++ b/src/Cottle/Documents/Emitted/StatementGenerators/ForStatementGenerator.cs
@@ -66,13 +66,13 @@ namespace Cottle.Documents.Emitted.StatementGenerators
             {
                 emitter.EmitLoadLocalAddress(pair);
                 emitter.EmitCallPairKey();
-                emitter.EmitStoreLocal(emitter.GetOrDeclareSymbol(_key.Value.Index));
+                emitter.EmitStoreLocal(emitter.GetOrDeclareLocal(_key.Value));
             }
 
             // Set current element value
             emitter.EmitLoadLocalAddressAndRelease(pair);
             emitter.EmitCallPairValue();
-            emitter.EmitStoreLocal(emitter.GetOrDeclareSymbol(_value.Index));
+            emitter.EmitStoreLocal(emitter.GetOrDeclareLocal(_value));
 
             // Evaluate body and restart cycle
             var exitReturn = emitter.DeclareLabel();

--- a/src/Cottle/Documents/EmittedDocument.cs
+++ b/src/Cottle/Documents/EmittedDocument.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using Cottle.Documents.Compiled;
 using Cottle.Documents.Emitted;

--- a/src/Cottle/Documents/Evaluated/Assembler.cs
+++ b/src/Cottle/Documents/Evaluated/Assembler.cs
@@ -9,20 +9,20 @@ namespace Cottle.Documents.Evaluated
 {
     internal class Assembler : AbstractAssembler<IStatementExecutor, IExpressionExecutor>
     {
-        protected override IStatementExecutor CreateStatementAssignFunction(Symbol symbol, int localCount,
+        protected override IStatementExecutor CreateStatementAssignFunction(Symbol symbol, StoreMode mode, int localCount,
             IReadOnlyList<Symbol> arguments, IStatementExecutor body)
         {
-            return new FunctionAssignStatementExecutor(symbol, localCount, arguments, body);
+            return new FunctionAssignStatementExecutor(symbol, mode, localCount, arguments, body);
         }
 
-        protected override IStatementExecutor CreateStatementAssignRender(Symbol symbol, IStatementExecutor body)
+        protected override IStatementExecutor CreateStatementAssignRender(Symbol symbol, StoreMode mode, IStatementExecutor body)
         {
-            return new RenderAssignStatementExecutor(symbol, body);
+            return new RenderAssignStatementExecutor(symbol, mode, body);
         }
 
-        protected override IStatementExecutor CreateStatementAssignValue(Symbol symbol, IExpressionExecutor expression)
+        protected override IStatementExecutor CreateStatementAssignValue(Symbol symbol, StoreMode mode, IExpressionExecutor expression)
         {
-            return new ValueAssignStatementExecutor(symbol, expression);
+            return new ValueAssignStatementExecutor(symbol, mode, expression);
         }
 
         protected override IStatementExecutor CreateStatementComposite(IReadOnlyList<IStatementExecutor> statements)
@@ -107,9 +107,9 @@ namespace Cottle.Documents.Evaluated
             return new MapExpressionExecutor(elements);
         }
 
-        protected override IExpressionExecutor CreateExpressionSymbol(Symbol symbol)
+        protected override IExpressionExecutor CreateExpressionSymbol(Symbol symbol, StoreMode mode)
         {
-            return new SymbolExpressionExecutor(symbol);
+            return new SymbolExpressionExecutor(symbol, mode);
         }
 
         protected override IExpressionExecutor CreateExpressionVoid()

--- a/src/Cottle/Documents/Evaluated/ExpressionExecutors/SymbolExpressionExecutor.cs
+++ b/src/Cottle/Documents/Evaluated/ExpressionExecutors/SymbolExpressionExecutor.cs
@@ -8,9 +8,16 @@ namespace Cottle.Documents.Evaluated.ExpressionExecutors
     {
         private readonly Func<Frame, Value> _getter;
 
-        public SymbolExpressionExecutor(Symbol symbol)
+        public SymbolExpressionExecutor(Symbol symbol, StoreMode mode)
         {
-            _getter = Frame.CreateGetter(symbol);
+            var index = symbol.Index;
+
+            _getter = mode switch
+            {
+                StoreMode.Global => frame => frame.Globals[index],
+                StoreMode.Local => frame => frame.Locals[index],
+                _ => throw new ArgumentOutOfRangeException(nameof(symbol))
+            };
         }
 
         public Value Execute(Frame frame, TextWriter output)

--- a/src/Cottle/Documents/Evaluated/StatementExecutors/Assign/RenderAssignStatementExecutor.cs
+++ b/src/Cottle/Documents/Evaluated/StatementExecutors/Assign/RenderAssignStatementExecutor.cs
@@ -7,8 +7,8 @@ namespace Cottle.Documents.Evaluated.StatementExecutors.Assign
     {
         private readonly IStatementExecutor _body;
 
-        public RenderAssignStatementExecutor(Symbol symbol, IStatementExecutor body) :
-            base(symbol)
+        public RenderAssignStatementExecutor(Symbol symbol, StoreMode mode, IStatementExecutor body) :
+            base(symbol, mode)
         {
             _body = body;
         }

--- a/src/Cottle/Documents/Evaluated/StatementExecutors/Assign/ValueAssignStatementExecutor.cs
+++ b/src/Cottle/Documents/Evaluated/StatementExecutors/Assign/ValueAssignStatementExecutor.cs
@@ -7,8 +7,8 @@ namespace Cottle.Documents.Evaluated.StatementExecutors.Assign
     {
         private readonly IExpressionExecutor _expression;
 
-        public ValueAssignStatementExecutor(Symbol symbol, IExpressionExecutor expression) :
-            base(symbol)
+        public ValueAssignStatementExecutor(Symbol symbol, StoreMode mode, IExpressionExecutor expression) :
+            base(symbol, mode)
         {
             _expression = expression;
         }

--- a/src/Cottle/Documents/Evaluated/StatementExecutors/AssignStatementExecutor.cs
+++ b/src/Cottle/Documents/Evaluated/StatementExecutors/AssignStatementExecutor.cs
@@ -8,9 +8,16 @@ namespace Cottle.Documents.Evaluated.StatementExecutors
     {
         private readonly Action<Frame, Value> _setter;
 
-        protected AssignStatementExecutor(Symbol symbol)
+        protected AssignStatementExecutor(Symbol symbol, StoreMode mode)
         {
-            _setter = Frame.CreateSetter(symbol);
+            var index = symbol.Index;
+
+            _setter = mode switch
+            {
+                StoreMode.Global => (frame, value) => frame.Globals[index] = value,
+                StoreMode.Local => (frame, value) => frame.Locals[index] = value,
+                _ => throw new ArgumentOutOfRangeException(nameof(symbol)),
+            };
         }
 
         public Value? Execute(Frame frame, TextWriter output)

--- a/src/Cottle/Documents/Evaluated/StatementExecutors/ForStatementExecutor.cs
+++ b/src/Cottle/Documents/Evaluated/StatementExecutors/ForStatementExecutor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using Cottle.Documents.Compiled;
 
 namespace Cottle.Documents.Evaluated.StatementExecutors
@@ -12,18 +11,17 @@ namespace Cottle.Documents.Evaluated.StatementExecutors
 
         private readonly IExpressionExecutor _from;
 
-        private readonly Action<Frame, Value>? _key;
+        private readonly Symbol? _key;
 
-        private readonly Action<Frame, Value> _value;
+        private readonly Symbol _value;
 
-        public ForStatementExecutor(IExpressionExecutor from, Symbol? key, Symbol value, IStatementExecutor body,
-            IStatementExecutor? empty)
+        public ForStatementExecutor(IExpressionExecutor from, Symbol? key, Symbol value, IStatementExecutor body, IStatementExecutor? empty)
         {
             _body = body;
             _empty = empty;
             _from = from;
-            _key = key.HasValue ? Frame.CreateSetter(key.Value) : null;
-            _value = Frame.CreateSetter(value);
+            _key = key;
+            _value = value;
         }
 
         public Value? Execute(Frame frame, TextWriter output)
@@ -34,10 +32,10 @@ namespace Cottle.Documents.Evaluated.StatementExecutors
             {
                 foreach (var pair in fields)
                 {
-                    if (_key != null)
-                        _key(frame, pair.Key);
+                    if (_key.HasValue)
+                        frame.Locals[_key.Value.Index] = pair.Key;
 
-                    _value(frame, pair.Value);
+                    frame.Locals[_value.Index] = pair.Value;
 
                     var result = _body.Execute(frame, output);
 

--- a/src/Cottle/Documents/EvaluatedDocument.cs
+++ b/src/Cottle/Documents/EvaluatedDocument.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.IO;
 using Cottle.Documents.Evaluated;
 


### PR DESCRIPTION
Some statements don't have configurable modes (e.g. "for" blocks) so it doesn't
make sense to have this information available and assumed constant.