### PR TITLE
Update Fluid Benchmark

### DIFF
--- a/src/Cottle.Benchmark/Benchmarks/CompareBenchmark.cs
+++ b/src/Cottle.Benchmark/Benchmarks/CompareBenchmark.cs
@@ -51,7 +51,7 @@ namespace Cottle.Benchmark.Benchmarks
             var rendererString = whitespaces.Replace(_renderer(), string.Empty);
 
             if (referenceString != rendererString)
-                throw new InvalidOperationException("Invalid output: " + rendererString);
+                throw new InvalidOperationException($"Invalid output: '{rendererString}' expected '{referenceString}'");
         }
     }
 }

--- a/src/Cottle.Benchmark/Cottle.Benchmark.csproj
+++ b/src/Cottle.Benchmark/Cottle.Benchmark.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="Fluid.Core" Version="2.4.0" />
     <PackageReference Include="Mustachio" Version="2.1.0" />
     <PackageReference Include="RazorLight" Version="2.3.0" />
-    <PackageReference Include="RazorEngineCore" Version="2022.1.2" />
     <PackageReference Include="Scriban" Version="5.7.0" />
   </ItemGroup>
 

--- a/src/Cottle.Benchmark/Cottle.Benchmark.csproj
+++ b/src/Cottle.Benchmark/Cottle.Benchmark.csproj
@@ -13,11 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-    <PackageReference Include="DotLiquid" Version="2.2.508" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+    <PackageReference Include="DotLiquid" Version="2.2.692" />
     <PackageReference Include="Fluid.Core" Version="2.4.0" />
     <PackageReference Include="Mustachio" Version="2.1.0" />
-    <PackageReference Include="RazorLight" Version="2.3.0" />
+    <PackageReference Include="RazorLight" Version="2.3.1" />
     <PackageReference Include="Scriban" Version="5.7.0" />
   </ItemGroup>
 

--- a/src/Cottle.Benchmark/Cottle.Benchmark.csproj
+++ b/src/Cottle.Benchmark/Cottle.Benchmark.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="DotLiquid" Version="2.2.508" />
     <PackageReference Include="Fluid.Core" Version="2.2.0" />
     <PackageReference Include="Mustachio" Version="2.1.0" />
+    <PackageReference Include="RazorEngineCore" Version="2022.1.2" />
     <PackageReference Include="RazorLight" Version="2.0.0-beta9" />
     <PackageReference Include="Scriban" Version="5.4.0" />
   </ItemGroup>

--- a/src/Cottle.Benchmark/Inputs/CompareEngine.cs
+++ b/src/Cottle.Benchmark/Inputs/CompareEngine.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using DotLiquid;
 using Fluid;
 using Fluid.Values;
+using RazorEngineCore;
 using RazorLight;
 using RazorLight.Razor;
 using Scriban;
@@ -227,6 +228,30 @@ namespace Cottle.Benchmark.Inputs
                 };
             });
 
+            // Render template with RazorEngineCore
+            yield return new Input<Func<Func<Func<string>>>>(nameof(RazorEngineCore), () =>
+            {
+                const string content = @"
+<ul id='products'>
+  @foreach (var product in Model.Products)
+  {
+    <li>
+      <h2>@product.Name</h2>
+      <p>@product.Description.Substring(0, System.Math.Min(product.Description.Length, 15)) - Only @product.Price.ToString(""f1"", System.Globalization.CultureInfo.CreateSpecificCulture(""en-US""))$</p>
+    </li>
+  }
+</ul>";
+
+                var context = new { Products = CompareEngine.Products };
+
+                return () =>
+                {
+                    var engine = new RazorEngine();
+                    var template = engine.Compile(content);
+                    return () => template.Run(context);
+                };
+            });
+
             // Render template with Scriban
             yield return new Input<Func<Func<Func<string>>>>(nameof(Scriban), () =>
             {
@@ -265,7 +290,7 @@ namespace Cottle.Benchmark.Inputs
         { Description = "Description " + new string('#', i + 1), Name = $"Product {i}", Price = i * 0.3f })
             .ToList();
 
-        public struct Product
+        public class Product
         {
             public string Description;
             public float Price;

--- a/src/Cottle.Benchmark/Inputs/CompareEngine.cs
+++ b/src/Cottle.Benchmark/Inputs/CompareEngine.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using DotLiquid;
 using Fluid;
 using Fluid.Values;
-using RazorEngineCore;
 using RazorLight;
 using RazorLight.Razor;
 using Scriban;
@@ -128,8 +127,8 @@ namespace Cottle.Benchmark.Inputs
 <ul id='products'>
   {% for product in products %}
     <li>
-      <h2>{{ product.Name }}</h2>
-      <p>{{ product.Description | safeslice: 0, 15 }} - Only {{ product.Price | tostring: ""f1"", ""en-US"" }}$</p>
+      <h2>{{ product.name }}</h2>
+      <p>{{ product.description | safeslice: 0, 15 }} - Only {{ product.price | tostring: ""f1"", ""en-US"" }}$</p>
     </li>
   {% endfor %}
 </ul>";
@@ -158,15 +157,21 @@ namespace Cottle.Benchmark.Inputs
                     return new StringValue(input.ToNumberValue().ToString(format, culture));
                 });
 
-                options.MemberAccessStrategy.Register<Product>(nameof(Product.Description), nameof(Product.Name), nameof(Product.Price));
+                var model = CompareEngine.Products
+                            .Select(p => new Dictionary<string, object>
+                            {
+                                ["description"] = p.Description,
+                                ["name"] = p.Name,
+                                ["price"] = p.Price
+                            })
+                            .ToArray();
 
-                var context = new Fluid.TemplateContext(options);
-
-                context.SetValue("products", CompareEngine.Products);
+                var parser = new FluidParser();
 
                 return () =>
                 {
-                    var parser = new FluidParser();
+                    var context = new Fluid.TemplateContext(options);
+                    context.SetValue("products", model);
 
                     if (!parser.TryParse(source, out var template, out var error))
                         throw new ArgumentOutOfRangeException(nameof(source), error);

--- a/src/Cottle.Benchmark/Inputs/CompareEngine.cs
+++ b/src/Cottle.Benchmark/Inputs/CompareEngine.cs
@@ -234,30 +234,6 @@ namespace Cottle.Benchmark.Inputs
                 };
             });
 
-            // Render template with RazorEngineCore
-            yield return new Input<Func<Func<Func<string>>>>(nameof(RazorEngineCore), () =>
-            {
-                const string content = @"
-<ul id='products'>
-  @foreach (var product in Model.Products)
-  {
-    <li>
-      <h2>@product.Name</h2>
-      <p>@product.Description.Substring(0, System.Math.Min(product.Description.Length, 15)) - Only @product.Price.ToString(""f1"", System.Globalization.CultureInfo.CreateSpecificCulture(""en-US""))$</p>
-    </li>
-  }
-</ul>";
-
-                var context = new { Products = CompareEngine.Products };
-
-                return () =>
-                {
-                    var engine = new RazorEngine();
-                    var template = engine.Compile(content);
-                    return () => template.Run(context);
-                };
-            });
-
             // Render template with Scriban
             yield return new Input<Func<Func<Func<string>>>>(nameof(Scriban), () =>
             {


### PR DESCRIPTION
Hello,

I noticed a couple issues with the Fluid benchmark:

1. The Cottle benchmark was mapping the Product objects into a dictionary whereas the Fluid benchmark was accessing properties on the object
2. The Fluid benchmark was re-creating the FluidParser each time which is thread safe and supposed to be shared
3. It wasn't re-creating the TemplateContext each time which apparently you are supposed to do

After making those updates I see that Fluid seems to have consistently less execution time and memory allocation than Cottle for both Create and Render.

Did I miss something in the benchmark? I'm just trying to do a fair evaluation of the two.

![image](https://user-images.githubusercontent.com/13984239/228866711-4d573991-3418-44ec-b03f-72752077a160.png)
