### PR TITLE
Partially revert split of "Severity" into "Type" & "Level".

### DIFF
--- a/src/Cottle.Demo/Forms/DemoForm.cs
+++ b/src/Cottle.Demo/Forms/DemoForm.cs
@@ -183,7 +183,7 @@ namespace Cottle.Demo.Forms
 
         private void DisplayResult(DocumentResult result)
         {
-            var messages = result.Reports.Select(r => $"{r.Message} ({r.Type} {r.Level})");
+            var messages = result.Reports.Select(r => $"{r.Message} ({r.Severity})");
 
             textBoxOutput.BackColor = Color.DarkSalmon;
             textBoxOutput.Text = string.Join(Environment.NewLine, messages);

--- a/src/Cottle.Test/Parsers/ForwardParserTester.cs
+++ b/src/Cottle.Test/Parsers/ForwardParserTester.cs
@@ -178,7 +178,7 @@ namespace Cottle.Test.Parsers
 
                 Assert.That(parser.Parse(reader, state, out _), Is.False);
 
-                var firstError = state.Reports.FirstOrDefault(r => r.Level == DocumentReportLevel.Error);
+                var firstError = state.Reports.FirstOrDefault(r => r.Severity == DocumentSeverity.Error);
 
                 Assert.That(firstError.Length, Is.EqualTo(expectedLength));
                 Assert.That(firstError.Message, Does.Contain(expectedMessage));

--- a/src/Cottle/DocumentReport.cs
+++ b/src/Cottle/DocumentReport.cs
@@ -1,46 +1,18 @@
-using System;
-
 namespace Cottle
 {
     public readonly struct DocumentReport
     {
         public readonly int Length;
-        public readonly DocumentReportLevel Level;
         public readonly string Message;
         public readonly int Offset;
         public readonly DocumentSeverity Severity;
-        public readonly DocumentReportType Type;
 
-        public DocumentReport(DocumentReportType type, DocumentReportLevel level, int offset, int length,
-            string message)
-        {
-            Length = length;
-            Level = level;
-            Message = message;
-            Offset = offset;
-            Severity = level switch
-            {
-                DocumentReportLevel.Notice => DocumentSeverity.Notice,
-                DocumentReportLevel.Warning => DocumentSeverity.Warning,
-                _ => DocumentSeverity.Error
-            };
-            Type = type;
-        }
-
-        [Obsolete("Provide `type` and `level` arguments as replacement for `severity`")]
         public DocumentReport(DocumentSeverity severity, int offset, int length, string message)
         {
             Length = length;
-            Level = severity switch
-            {
-                DocumentSeverity.Notice => DocumentReportLevel.Notice,
-                DocumentSeverity.Warning => DocumentReportLevel.Warning,
-                _ => DocumentReportLevel.Error
-            };
             Message = message;
             Offset = offset;
             Severity = severity;
-            Type = DocumentReportType.Language;
         }
     }
 }

--- a/src/Cottle/DocumentReportLevel.cs
+++ b/src/Cottle/DocumentReportLevel.cs
@@ -1,9 +1,0 @@
-namespace Cottle
-{
-    public enum DocumentReportLevel
-    {
-        Error,
-        Warning,
-        Notice
-    }
-}

--- a/src/Cottle/DocumentReportType.cs
+++ b/src/Cottle/DocumentReportType.cs
@@ -1,7 +1,0 @@
-namespace Cottle
-{
-    public enum DocumentReportType
-    {
-        Language
-    }
-}

--- a/src/Cottle/DocumentResult.cs
+++ b/src/Cottle/DocumentResult.cs
@@ -18,14 +18,9 @@ namespace Cottle
                 if (Reports.Count < 1)
                     throw new ParseException(0, 0, "unknown error");
 
-                var report = Reports.OrderBy(report => report.Level).First();
+                var report = Reports.OrderBy(report => report.Severity).First();
 
-                throw report.Type switch
-                {
-                    DocumentReportType.Language => new ParseException(report.Offset, report.Length, report.Message),
-                    _ => new InvalidOperationException(
-                        "internal error, please file a report at https://github.com/r3c/cottle/issues")
-                };
+                throw new ParseException(report.Offset, report.Length, report.Message);
             }
         }
 

--- a/src/Cottle/Documents/AbstractDocument.cs
+++ b/src/Cottle/Documents/AbstractDocument.cs
@@ -36,7 +36,7 @@ namespace Cottle.Documents
 
         internal static ParseException CreateException(IEnumerable<DocumentReport> reports)
         {
-            var firstError = reports.FirstOrDefault(r => r.Level == DocumentReportLevel.Error);
+            var firstError = reports.FirstOrDefault(r => r.Severity == DocumentSeverity.Error);
 
             throw new ParseException(firstError.Offset, firstError.Length, firstError.Message ?? "unknown error");
         }

--- a/src/Cottle/Parsers/ForwardParser.cs
+++ b/src/Cottle/Parsers/ForwardParser.cs
@@ -989,8 +989,7 @@ namespace Cottle.Parsers
             var current = _lexer.Current;
             var message = $"expected {expected}, found {current.Value}";
 
-            return new DocumentReport(DocumentReportType.Language, DocumentReportLevel.Error, current.Offset,
-                current.Length, message);
+            return new DocumentReport(DocumentSeverity.Error, current.Offset, current.Length, message);
         }
 
         private DocumentReport CreateReportObsolete(string obsolete, string replacement)
@@ -998,8 +997,7 @@ namespace Cottle.Parsers
             var current = _lexer.Current;
             var message = $"{obsolete} is obsolete, please replace with {replacement}";
 
-            return new DocumentReport(DocumentReportType.Language, DocumentReportLevel.Notice, current.Offset,
-                current.Length, message);
+            return new DocumentReport(DocumentSeverity.Notice, current.Offset, current.Length, message);
         }
     }
 }


### PR DESCRIPTION
There is no practical need for it right now, so let's not change the API.