### PR TITLE
Do not require `state` argument in runtime Echo method.

### DIFF
--- a/src/Cottle/Documents/Emitted/Emitter.cs
+++ b/src/Cottle/Documents/Emitted/Emitter.cs
@@ -30,7 +30,7 @@ namespace Cottle.Documents.Emitted
             Dynamic.GetField<Func<Frame, IReadOnlyList<Value>>>(f => f.Constants);
 
         private static readonly MethodInfo RuntimeEcho =
-            Dynamic.GetMethod<Func<Runtime, string>>(r => r.Echo(default!, default, TextWriter.Null));
+            Dynamic.GetMethod<Func<Runtime, string>>(r => r.Echo(default, TextWriter.Null));
 
         private static readonly MethodInfo RuntimeUnwrap =
             Dynamic.GetMethod<Func<Runtime, IFunction>>(r => r.Unwrap());
@@ -254,7 +254,6 @@ namespace Cottle.Documents.Emitted
         public void EmitCallRuntimeEcho(Local<Value> value)
         {
             EmitLoadRuntime();
-            EmitLoadState();
             EmitLoadLocalValueAndRelease(value);
             EmitLoadOutput();
 

--- a/src/Cottle/Documents/Evaluated/StatementExecutors/EchoStatementExecutor.cs
+++ b/src/Cottle/Documents/Evaluated/StatementExecutors/EchoStatementExecutor.cs
@@ -14,7 +14,7 @@ namespace Cottle.Documents.Evaluated.StatementExecutors
         public Value? Execute(Runtime runtime, Frame frame, TextWriter output)
         {
             var subject = _expression.Execute(runtime, frame, output);
-            var value = runtime.Echo(runtime, subject, output);
+            var value = runtime.Echo(subject, output);
 
             output.Write(value);
 

--- a/src/Cottle/Runtime.cs
+++ b/src/Cottle/Runtime.cs
@@ -23,7 +23,7 @@ namespace Cottle
             _nbCycle = 0;
         }
 
-        public string Echo(object state, Value value, TextWriter output)
+        public string Echo(Value value, TextWriter output)
         {
             if (_modifiers.Count < 1)
                 return value.AsString;
@@ -31,9 +31,9 @@ namespace Cottle
             foreach (var modifier in _modifiers)
             {
                 if (modifier is FiniteFunction finiteModifier)
-                    value = finiteModifier.Invoke1(state, value, output);
+                    value = finiteModifier.Invoke1(this, value, output);
                 else
-                    value = modifier.Invoke(state, new[] { value }, output);
+                    value = modifier.Invoke(this, new[] { value }, output);
             }
 
             return value.AsString;


### PR DESCRIPTION
This value is already available as being the runtime instance itself.