### PR TITLE
Lazily scan recursive schema for `Value.FromReflection`.

### DIFF
--- a/src/Cottle/Exceptions/ReflectionTypeException.cs
+++ b/src/Cottle/Exceptions/ReflectionTypeException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Cottle.Exceptions
+{
+    public class ReflectionTypeException : Exception
+    {
+        public Type Type { get; }
+
+        internal ReflectionTypeException(Type type, Exception innerException)
+            : base($"Unable to convert type '{type.FullName}'", innerException)
+        {
+            Type = type;
+        }
+    }
+}

--- a/src/Cottle/Exceptions/UnconvertiblePropertyException.cs
+++ b/src/Cottle/Exceptions/UnconvertiblePropertyException.cs
@@ -3,12 +3,12 @@ using System.Reflection;
 
 namespace Cottle.Exceptions
 {
-    public sealed class UnconvertiblePropertyException : Exception
+    public sealed class UnconvertiblePropertyException : ReflectionTypeException
     {
         public PropertyInfo PropertyInfo { get; }
 
         public UnconvertiblePropertyException(PropertyInfo propertyInfo, Exception innerException)
-            : base($"Unable to create converter for property '{propertyInfo}'", innerException)
+            : base(propertyInfo.PropertyType, innerException)
         {
             PropertyInfo = propertyInfo;
         }

--- a/src/Cottle/Value.cs
+++ b/src/Cottle/Value.cs
@@ -264,7 +264,7 @@ namespace Cottle
 
         public static Value FromReflection<TSource>(TSource source, BindingFlags bindingFlags)
         {
-            return ReflectionEvaluable.CreateValue(source, bindingFlags);
+            return new Value(ReflectionEvaluable.CreateEvaluable(source, bindingFlags));
         }
 
         public static Value FromString(string? value)

--- a/src/Cottle/Values/ReflectionValue.cs
+++ b/src/Cottle/Values/ReflectionValue.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Reflection;
-using Cottle.Evaluables;
 
 namespace Cottle.Values
 {
@@ -24,7 +23,7 @@ namespace Cottle.Values
 
         protected override Value Resolve()
         {
-            return ReflectionEvaluable.CreateValue(_source, _bindingFlags);
+            return Value.FromReflection(_source, _bindingFlags);
         }
     }
 }


### PR DESCRIPTION
This approach avoids crashing when a never-accessed field cannot be resolved through reflection.